### PR TITLE
Make adjustments per the OT-go SpanContext changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Travis CI](https://travis-ci.org/openzipkin/zipkin-go-opentracing.svg?branch=master)](https://travis-ci.org/openzipkin/zipkin-go-opentracing)
 [![GoDoc](https://godoc.org/github.com/openzipkin/zipkin-go-opentracing?status.svg)](https://godoc.org/github.com/openzipkin/zipkin-go-opentracing)
 
-OpenTracing Tracer implementation for Zipkin in Go.
+[OpenTracing](http://opentracing.io/) Tracer implementation for Zipkin in Go.

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -89,11 +89,9 @@ func TestConcurrentUsage(t *testing.T) {
 				sp := tracer.StartSpan(op)
 				sp.LogEvent("test event")
 				sp.SetTag("foo", "bar")
-				sp.SetBaggageItem("boo", "far")
+				sp.Context().SetBaggageItem("boo", "far")
 				sp.SetOperationName("x")
-				csp := tracer.StartSpanWithOptions(opentracing.StartSpanOptions{
-					Parent: sp,
-				})
+				csp := tracer.StartSpan("c", opentracing.ChildOf(sp.Context()))
 				csp.Finish()
 				defer sp.Finish()
 			}

--- a/event.go
+++ b/event.go
@@ -14,11 +14,6 @@ type EventTag struct {
 	Value interface{}
 }
 
-// EventBaggage is received when SetBaggageItem is called.
-type EventBaggage struct {
-	Key, Value string
-}
-
 // EventLog is received when Log (or one of its derivatives) is called.
 type EventLog opentracing.LogData
 
@@ -38,11 +33,6 @@ func (s *spanImpl) onTag(key string, value interface{}) {
 func (s *spanImpl) onLog(ld opentracing.LogData) {
 	if s.event != nil {
 		s.event(EventLog(ld))
-	}
-}
-func (s *spanImpl) onBaggage(key, value string) {
-	if s.event != nil {
-		s.event(EventBaggage{Key: key, Value: value})
 	}
 }
 func (s *spanImpl) onFinish(sp RawSpan) {

--- a/raw.go
+++ b/raw.go
@@ -27,7 +27,4 @@ type RawSpan struct {
 
 	// The span's "microlog".
 	Logs []opentracing.LogData
-
-	// The span's associated baggage.
-	Baggage map[string]string // initialized on first use
 }

--- a/raw.go
+++ b/raw.go
@@ -10,7 +10,7 @@ import (
 type RawSpan struct {
 	// The RawSpan embeds its Context. Those recording the RawSpan
 	// should also record the contents of its Context.
-	Context
+	*Context
 
 	// The name of the "operation" this span is an instance of. (Called a "span
 	// name" in some implementations)

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -45,7 +45,7 @@ func TestInMemoryRecorderSpans(t *testing.T) {
 	recorder := NewInMemoryRecorder()
 	var apiRecorder SpanRecorder = recorder
 	span := RawSpan{
-		Context:   Context{},
+		Context:   &Context{},
 		Operation: "test-span",
 		Start:     time.Now(),
 		Duration:  -1,

--- a/span.go
+++ b/span.go
@@ -51,7 +51,9 @@ func (s *spanImpl) reset() {
 	// a buffer pool when GC considers them unreachable, which should ease
 	// some of the load. Hard to say how quickly that would be in practice
 	// though.
-	s.raw = RawSpan{}
+	s.raw = RawSpan{
+		Context: &Context{},
+	}
 }
 
 func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
@@ -144,7 +146,7 @@ func (s *spanImpl) Tracer() opentracing.Tracer {
 }
 
 func (s *spanImpl) Context() opentracing.SpanContext {
-	return &s.raw.Context
+	return s.raw.Context
 }
 
 func (s *spanImpl) Operation() string {

--- a/span.go
+++ b/span.go
@@ -1,7 +1,6 @@
 package zipkintracer
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -16,9 +15,6 @@ import (
 // to (*opentracing.Span).Finish().
 type Span interface {
 	opentracing.Span
-
-	// Context contains trace identifiers
-	Context() Context
 
 	// Operation names the work done by this span instance
 	Operation() string
@@ -37,10 +33,6 @@ type spanImpl struct {
 	Endpoint   *zipkincore.Endpoint
 	sampled    bool
 }
-
-var spanPool = &sync.Pool{New: func() interface{} {
-	return &spanImpl{}
-}}
 
 func (s *spanImpl) reset() {
 	s.tracer, s.event = nil, nil
@@ -145,57 +137,14 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 		// operation since s.tracer is accessed on every call to `Lock`.
 		s.reset()
 	}
-	spanPool.Put(s)
-}
-
-func (s *spanImpl) SetBaggageItem(restrictedKey, val string) opentracing.Span {
-	canonicalKey, valid := opentracing.CanonicalizeBaggageKey(restrictedKey)
-	if !valid {
-		panic(fmt.Errorf("Invalid key: %q", restrictedKey))
-	}
-
-	s.Lock()
-	defer s.Unlock()
-	s.onBaggage(canonicalKey, val)
-	if s.trim() {
-		return s
-	}
-
-	if s.raw.Baggage == nil {
-		s.raw.Baggage = make(map[string]string)
-	}
-	s.raw.Baggage[canonicalKey] = val
-	return s
-}
-
-func (s *spanImpl) BaggageItem(restrictedKey string) string {
-	canonicalKey, valid := opentracing.CanonicalizeBaggageKey(restrictedKey)
-	if !valid {
-		panic(fmt.Errorf("Invalid key: %q", restrictedKey))
-	}
-
-	s.Lock()
-	defer s.Unlock()
-
-	return s.raw.Baggage[canonicalKey]
-}
-
-func (s *spanImpl) ForeachBaggageItem(handler func(k, v string) bool) {
-	s.Lock()
-	defer s.Unlock()
-	for k, v := range s.raw.Baggage {
-		if !handler(k, v) {
-			break
-		}
-	}
 }
 
 func (s *spanImpl) Tracer() opentracing.Tracer {
 	return s.tracer
 }
 
-func (s *spanImpl) Context() Context {
-	return s.raw.Context
+func (s *spanImpl) Context() opentracing.SpanContext {
+	return &s.raw.Context
 }
 
 func (s *spanImpl) Operation() string {

--- a/tracer.go
+++ b/tracer.go
@@ -186,7 +186,11 @@ func (t *tracerImpl) StartSpanWithOptions(
 
 	// Build the new span. This is the only allocation: We'll return this as
 	// an opentracing.Span.
-	sp := &spanImpl{}
+	sp := &spanImpl{
+		raw: RawSpan{
+			Context: &Context{},
+		},
+	}
 	// Look for a parent in the list of References.
 	//
 	// TODO: would be nice if basictracer did something with all


### PR DESCRIPTION
Make the zipkin-go-opentracing Context object implement opentracing.SpanContext, migrate the old Join concept to Extract, fix per the StartSpan changes, and get all tests to pass.

I am confident about the OpenTracing pieces of this but will point out a few Zipkin-related questions I have.

cc: @basvanbeek 