### PR TITLE
Implement immutable SpanContexts

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -26,7 +26,7 @@ func executeOps(sp opentracing.Span, numEvent, numTag, numItems int) {
 		sp.SetTag(tags[j], nil)
 	}
 	for j := 0; j < numItems; j++ {
-		sp.Context().SetBaggageItem(tags[j], tags[j])
+		sp.SetBaggageItem(tags[j], tags[j])
 	}
 }
 
@@ -82,14 +82,6 @@ func BenchmarkSpan_100BaggageItems(b *testing.B) {
 func BenchmarkTrimmedSpan_100Events_100Tags_100BaggageItems(b *testing.B) {
 	var r CountingRecorder
 	t, err := NewTracer(
-		&r,
-		TrimUnsampledSpans(true),
-		WithSampler(neverSample),
-	)
-	if err != nil {
-		b.Fatalf("Unable to create Tracer: %+v", err)
-	}
-	t, err = NewTracer(
 		&r,
 		TrimUnsampledSpans(true),
 		WithSampler(neverSample),
@@ -153,8 +145,8 @@ func benchmarkExtract(b *testing.B, format opentracing.BuiltinFormat, numItems i
 		b.Fatal(err)
 	}
 
-	// We create a new bytes.Buffer every time for tracer.Extract() to keep this
-	// benchmark realistic.
+	// We create a new bytes.Buffer every time for tracer.Extract() to keep
+	// this benchmark realistic.
 	var rawBinaryBytes []byte
 	if format == opentracing.Binary {
 		rawBinaryBytes = carrier.(*bytes.Buffer).Bytes()

--- a/collector-scribe_test.go
+++ b/collector-scribe_test.go
@@ -116,7 +116,9 @@ func newScribeServer(t *testing.T) *scribeServer {
 		protocolFactory,
 	)
 
-	go server.Serve()
+	go func() {
+		_ = server.Serve()
+	}()
 
 	deadline := time.Now().Add(time.Second)
 	for !canConnect(port) {

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -92,7 +92,7 @@ func TestConcurrentUsage(t *testing.T) {
 				sp := tracer.StartSpan(op)
 				sp.LogEvent("test event")
 				sp.SetTag("foo", "bar")
-				sp.Context().SetBaggageItem("boo", "far")
+				sp.SetBaggageItem("boo", "far")
 				sp.SetOperationName("x")
 				csp := tracer.StartSpan(
 					"csp",

--- a/propagation.go
+++ b/propagation.go
@@ -27,7 +27,7 @@ func (p *accessorPropagator) Inject(
 	if !ok || dc == nil {
 		return opentracing.ErrInvalidCarrier
 	}
-	sc, ok := spanContext.(*SpanContext)
+	sc, ok := spanContext.(SpanContext)
 	if !ok {
 		return opentracing.ErrInvalidSpanContext
 	}
@@ -47,11 +47,12 @@ func (p *accessorPropagator) Extract(
 	}
 
 	traceID, spanID, parentSpanID, sampled, flags := dc.State()
-	sc := &SpanContext{
+	sc := SpanContext{
 		TraceID:      traceID,
 		SpanID:       spanID,
-		ParentSpanID: parentSpanID,
 		Sampled:      sampled,
+		Baggage:      nil,
+		ParentSpanID: parentSpanID,
 		Flags:        flags,
 	}
 	dc.GetBaggage(func(k, v string) {

--- a/raw.go
+++ b/raw.go
@@ -8,9 +8,9 @@ import (
 
 // RawSpan encapsulates all state associated with a (finished) Span.
 type RawSpan struct {
-	// The RawSpan embeds its SpanContext. Those recording the RawSpan
-	// should also record the contents of its SpanContext.
-	*SpanContext
+	// Those recording the RawSpan should also record the contents of its
+	// SpanContext.
+	Context SpanContext
 
 	// The name of the "operation" this span is an instance of. (Called a "span
 	// name" in some implementations)

--- a/recorder.go
+++ b/recorder.go
@@ -45,7 +45,7 @@ func (r *InMemorySpanRecorder) GetSampledSpans() []RawSpan {
 	defer r.RUnlock()
 	spans := make([]RawSpan, 0, len(r.spans))
 	for _, span := range r.spans {
-		if span.Sampled {
+		if span.Context.Sampled {
 			spans = append(spans, span)
 		}
 	}

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -12,10 +12,10 @@ func TestInMemoryRecorderSpans(t *testing.T) {
 	recorder := NewInMemoryRecorder()
 	var apiRecorder SpanRecorder = recorder
 	span := RawSpan{
-		SpanContext: &SpanContext{},
-		Operation:   "test-span",
-		Start:       time.Now(),
-		Duration:    -1,
+		Context:   SpanContext{},
+		Operation: "test-span",
+		Start:     time.Now(),
+		Duration:  -1,
 	}
 	apiRecorder.RecordSpan(span)
 	assert.Equal(t, []RawSpan{span}, recorder.GetSpans())

--- a/span_test.go
+++ b/span_test.go
@@ -3,6 +3,7 @@ package zipkintracer
 import (
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,16 +19,16 @@ func TestSpan_Baggage(t *testing.T) {
 	}
 
 	span := tracer.StartSpan("x")
-	span.Context().SetBaggageItem("x", "y")
-	assert.Equal(t, "y", span.Context().BaggageItem("x"))
+	span.SetBaggageItem("x", "y")
+	assert.Equal(t, "y", span.BaggageItem("x"))
 	span.Finish()
 	spans := recorder.GetSpans()
 	assert.Equal(t, 1, len(spans))
-	assert.Equal(t, map[string]string{"x": "y"}, spans[0].Baggage)
+	assert.Equal(t, map[string]string{"x": "y"}, spans[0].Context.Baggage)
 
 	recorder.Reset()
 	span = tracer.StartSpan("x")
-	span.Context().SetBaggageItem("x", "y")
+	span.SetBaggageItem("x", "y")
 	baggage := make(map[string]string)
 	span.Context().ForeachBaggageItem(func(k, v string) bool {
 		baggage[k] = v
@@ -35,7 +36,7 @@ func TestSpan_Baggage(t *testing.T) {
 	})
 	assert.Equal(t, map[string]string{"x": "y"}, baggage)
 
-	span.Context().SetBaggageItem("a", "b")
+	span.SetBaggageItem("a", "b")
 	baggage = make(map[string]string)
 	span.Context().ForeachBaggageItem(func(k, v string) bool {
 		baggage[k] = v
@@ -45,7 +46,7 @@ func TestSpan_Baggage(t *testing.T) {
 	span.Finish()
 	spans = recorder.GetSpans()
 	assert.Equal(t, 1, len(spans))
-	assert.Equal(t, 2, len(spans[0].Baggage))
+	assert.Equal(t, 2, len(spans[0].Context.Baggage))
 }
 
 func TestSpan_Sampling(t *testing.T) {
@@ -86,4 +87,95 @@ func TestSpan_Sampling(t *testing.T) {
 	ext.SamplingPriority.Set(span, 1)
 	span.Finish()
 	assert.Equal(t, 1, len(recorder.GetSampledSpans()), "SamplingPriority=1 should turn on sampling")
+}
+
+func TestSpan_SingleLoggedTaggedSpan(t *testing.T) {
+	recorder := NewInMemoryRecorder()
+	tracer, err := NewTracer(
+		recorder,
+		WithSampler(func(_ uint64) bool { return true }),
+	)
+	if err != nil {
+		t.Fatalf("Unable to create Tracer: %+v", err)
+	}
+
+	span := tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans := recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, "x", spans[0].Operation)
+	assert.Equal(t, 1, len(spans[0].Logs))
+	assert.Equal(t, "event", spans[0].Logs[0].Event)
+	assert.Equal(t, "payload", spans[0].Logs[0].Payload)
+	assert.Equal(t, opentracing.Tags{"tag": "value"}, spans[0].Tags)
+}
+
+func TestSpan_TrimUnsampledSpans(t *testing.T) {
+	recorder := NewInMemoryRecorder()
+	// Tracer that trims only unsampled but always samples
+	tracer, err := NewTracer(
+		recorder,
+		WithSampler(func(_ uint64) bool { return true }),
+		TrimUnsampledSpans(true),
+	)
+	if err != nil {
+		t.Fatalf("Unable to create Tracer: %+v", err)
+	}
+
+	span := tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans := recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, 1, len(spans[0].Logs))
+	assert.Equal(t, "event", spans[0].Logs[0].Event)
+	assert.Equal(t, "payload", spans[0].Logs[0].Payload)
+	assert.Equal(t, opentracing.Tags{"tag": "value"}, spans[0].Tags)
+
+	recorder.Reset()
+	// Tracer that trims only unsampled and never samples
+	tracer, err = NewTracer(
+		recorder,
+		WithSampler(func(_ uint64) bool { return false }),
+		TrimUnsampledSpans(true),
+	)
+	if err != nil {
+		t.Fatalf("Unable to create Tracer: %+v", err)
+	}
+
+	span = tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans = recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, 0, len(spans[0].Logs))
+	assert.Equal(t, 0, len(spans[0].Tags))
+}
+
+func TestSpan_DropAllLogs(t *testing.T) {
+	recorder := NewInMemoryRecorder()
+	// Tracer that drops logs
+	tracer, err := NewTracer(
+		recorder,
+		WithSampler(func(_ uint64) bool { return true }),
+		DropAllLogs(true),
+	)
+	if err != nil {
+		t.Fatalf("Unable to create Tracer: %+v", err)
+	}
+
+	span := tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans := recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, "x", spans[0].Operation)
+	assert.Equal(t, opentracing.Tags{"tag": "value"}, spans[0].Tags)
+	// Only logs are dropped
+	assert.Equal(t, 0, len(spans[0].Logs))
 }


### PR DESCRIPTION
Added BaggageItem method to adhere to OpenTracing Interface update and mirrored the immutable SpanContexts logic as shown in the basictracer-go implementation