### PR TITLE
moved thrift import dependencies from apache to github repository

### DIFF
--- a/_thrift/compile.sh
+++ b/_thrift/compile.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 for f in *.thrift ; do
-	thrift -r --gen go:thrift_import=git.apache.org/thrift.git/lib/go/thrift $f
+	thrift -r --gen go:thrift_import=github.com/apache/thrift/lib/go/thrift $f
 done

--- a/_thrift/gen-go/scribe/constants.go
+++ b/_thrift/gen-go/scribe/constants.go
@@ -6,7 +6,7 @@ package scribe
 import (
 	"bytes"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/_thrift/gen-go/scribe/scribe-remote/scribe-remote.go
+++ b/_thrift/gen-go/scribe/scribe-remote/scribe-remote.go
@@ -6,7 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"math"
 	"net"
 	"net/url"

--- a/_thrift/gen-go/scribe/scribe.go
+++ b/_thrift/gen-go/scribe/scribe.go
@@ -6,7 +6,7 @@ package scribe
 import (
 	"bytes"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/_thrift/gen-go/scribe/ttypes.go
+++ b/_thrift/gen-go/scribe/ttypes.go
@@ -6,7 +6,7 @@ package scribe
 import (
 	"bytes"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/_thrift/gen-go/zipkincore/constants.go
+++ b/_thrift/gen-go/zipkincore/constants.go
@@ -6,8 +6,7 @@ package zipkincore
 import (
 	"bytes"
 	"fmt"
-
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/_thrift/gen-go/zipkincore/ttypes.go
+++ b/_thrift/gen-go/zipkincore/ttypes.go
@@ -6,7 +6,7 @@ package zipkincore
 import (
 	"bytes"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/collector-kafka.go
+++ b/collector-kafka.go
@@ -1,8 +1,8 @@
 package zipkintracer
 
 import (
-	"git.apache.org/thrift.git/lib/go/thrift"
 	"github.com/Shopify/sarama"
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/openzipkin/zipkin-go-opentracing/_thrift/gen-go/zipkincore"
 )

--- a/collector-kafka_test.go
+++ b/collector-kafka_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
 	"github.com/Shopify/sarama"
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/openzipkin/zipkin-go-opentracing/_thrift/gen-go/zipkincore"
 )

--- a/collector-scribe.go
+++ b/collector-scribe.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/openzipkin/zipkin-go-opentracing/_thrift/gen-go/scribe"
 	"github.com/openzipkin/zipkin-go-opentracing/_thrift/gen-go/zipkincore"

--- a/collector-scribe_test.go
+++ b/collector-scribe_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/openzipkin/zipkin-go-opentracing/_thrift/gen-go/scribe"
 	"github.com/openzipkin/zipkin-go-opentracing/_thrift/gen-go/zipkincore"


### PR DESCRIPTION
Official apache thrift git repository is often slow and sometimes seems down. This introduces dependency import problems for Go projects using `zipkin-go-opentracing`. 

Moving to the github mirror might remedy these issues like #20 