### PR TITLE
bugfixes to endpoint serialization and RPC same span handling

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -268,8 +268,9 @@ ReferencesLoop:
 			sp.raw.Context.Flags = refCtx.Flags
 			sp.raw.Context.Flags &^= flag.IsRoot // unset IsRoot flag if needed
 
-			if tags[string(ext.SpanKind)] == ext.SpanKindRPCServer &&
-				t.options.clientServerSameSpan {
+			if t.options.clientServerSameSpan &&
+				tags[string(ext.SpanKind)] == ext.SpanKindRPCServer.Value {
+
 				sp.raw.Context.SpanID = refCtx.SpanID
 				sp.raw.Context.ParentSpanID = refCtx.ParentSpanID
 			} else {

--- a/zipkin-endpoint.go
+++ b/zipkin-endpoint.go
@@ -17,7 +17,7 @@ func makeEndpoint(hostport, serviceName string) *zipkincore.Endpoint {
 		return nil
 	}
 
-	portInt, err := strconv.ParseInt(port, 10, 16)
+	portInt, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Very high port numbers where not serialized into the Zipkin struct properly due to using int16 instead of uint16 and therefore failing to create the Zipkin endpoint structs.

Also fixed Zipkin V1 style same span for Client and Server node. This has been broken since some OT update to the ext package.
