### PR TITLE
Tolerate 128bit trace ids by throwing out high bits

### DIFF
--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -88,6 +88,12 @@ func (p *textMapPropagator) Extract(
 	err = carrier.ForeachKey(func(k, v string) error {
 		switch strings.ToLower(k) {
 		case zipkinTraceIDLower:
+			// TODO: add logic for most significant 64 bits when 128bit traceID's are
+			// supported.
+			// SEE: https://github.com/openzipkin/b3-propagation/issues/6
+			if len(v) > 16 {
+				v = v[len(v)-16:]
+			}
 			traceID, err = strconv.ParseUint(v, 16, 64)
 			if err != nil {
 				return opentracing.ErrSpanContextCorrupted


### PR DESCRIPTION
This bridges support for 128bit trace ids by not failing on their
receipt. Basically, this throws out any hex characters to the left
of the 16 needed for the 64bit trace id.

see: https://github.com/openzipkin/b3-propagation/issues/6