### PR TITLE
Check http batch size before sending

### DIFF
--- a/collector-http.go
+++ b/collector-http.go
@@ -122,7 +122,7 @@ func (c *HTTPCollector) loop() {
 				go c.sendNow()
 			}
 		case <-tickc:
-			if time.Now().After(c.nextSend) {
+			if time.Now().After(c.nextSend) && len(c.batch) > 0 {
 				go c.sendNow()
 			}
 		case <-c.sendc:

--- a/collector-scribe.go
+++ b/collector-scribe.go
@@ -92,7 +92,7 @@ func (c *ScribeCollector) loop() {
 			}
 
 		case <-tickc:
-			if time.Now().After(c.nextSend) {
+			if time.Now().After(c.nextSend) && len(c.batch) > 0 {
 				go c.sendNow()
 			}
 


### PR DESCRIPTION
Look at this method,  the loop goroutine posts empty span list every interval, which is inefficient.
```go
func (c *HTTPCollector) loop() {
	tickc := time.Tick(c.batchInterval / 10)

	for {
		select {
		case span := <-c.spanc:
			c.batch = append(c.batch, span)
			if len(c.batch) >= c.batchSize {
				go c.sendNow()
			}
		case <-tickc:
			if time.Now().After(c.nextSend) {
				go c.sendNow()
			}
		case <-c.sendc:
			c.nextSend = time.Now().Add(c.batchInterval)
			if err := c.send(c.batch); err != nil {
				_ = c.logger.Log("err", err.Error())
			}
			c.batch = c.batch[:0]
		case <-c.quit:
			return
		}
	}
}
```
when ticker timeout, this goroutine will send c.batch to zipkin even though c.batch is empty. It should check the batch's size? like below:
```go
                case <-tickc:
			if time.Now().After(c.nextSend) && len(c.batch) > 0 {
				go c.sendNow()
			}
```