### PR TITLE
Drain collector buffer on Close

### DIFF
--- a/collector-http_test.go
+++ b/collector-http_test.go
@@ -33,21 +33,11 @@ func TestHttpCollector(t *testing.T) {
 	if err := c.Collect(span); err != nil {
 		t.Errorf("error during collection: %v", err)
 	}
-
-	// Need to yield to the select loop to accept the send request, and then
-	// yield again to the send operation to write to the socket. I think the
-	// best way to do that is just give it some time.
-
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if time.Now().After(deadline) {
-			t.Fatalf("never received a span")
-		}
-		if want, have := 1, len(server.spans()); want != have {
-			time.Sleep(time.Millisecond)
-			continue
-		}
-		break
+	if err := c.Close(); err != nil {
+		t.Fatalf("error during collection: %v", err)
+	}
+	if want, have := 1, len(server.spans()); want != have {
+		t.Fatalf("never received a span")
 	}
 
 	gotSpan := server.spans()[0]

--- a/collector-scribe_test.go
+++ b/collector-scribe_test.go
@@ -39,21 +39,11 @@ func TestScribeCollector(t *testing.T) {
 	if err := c.Collect(span); err != nil {
 		t.Errorf("error during collection: %v", err)
 	}
-
-	// Need to yield to the select loop to accept the send request, and then
-	// yield again to the send operation to write to the socket. I think the
-	// best way to do that is just give it some time.
-
-	deadline := time.Now().Add(1 * time.Second)
-	for {
-		if time.Now().After(deadline) {
-			t.Fatalf("never received a span")
-		}
-		if want, have := 1, len(server.spans()); want != have {
-			time.Sleep(time.Millisecond)
-			continue
-		}
-		break
+	if err := c.Close(); err != nil {
+		t.Fatalf("error during collection: %v", err)
+	}
+	if want, have := 1, len(server.spans()); want != have {
+		t.Fatalf("never received a span")
 	}
 
 	gotSpan := server.spans()[0]

--- a/examples/cli_with_2_services/cli/main.go
+++ b/examples/cli_with_2_services/cli/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
@@ -60,7 +59,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	// Explicitely set our tracer to be the default tracer.
+	// Explicitly set our tracer to be the default tracer.
 	opentracing.InitGlobalTracer(tracer)
 
 	// Create Client to svc1 Service
@@ -85,6 +84,6 @@ func main() {
 	// Finish our CLI span
 	span.Finish()
 
-	// Wait some time for the spans to be sent to the collector before exiting
-	time.Sleep(2 * time.Second)
+	// Close collector to ensure spans are sent before exiting.
+	collector.Close()
 }


### PR DESCRIPTION
Update the Close() logic of the HTTP and Scribe Collectors to drain any
pending spans before returning. This provides a mechanism to prevent
loss of buffered trace data when shutting down.

This is of particular use for short lived processes such as cli clients.