### PR TITLE
Fixes #39: http-collector non-blocking collect

### DIFF
--- a/collector-http_test.go
+++ b/collector-http_test.go
@@ -9,12 +9,21 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
+	"fmt"
 	"github.com/openzipkin/zipkin-go-opentracing/_thrift/gen-go/zipkincore"
 )
 
+const (
+	interval    = 10 * time.Millisecond
+	serverSleep = 100 * time.Millisecond
+)
+
 func TestHttpCollector(t *testing.T) {
-	server := newHTTPServer(t)
-	c, err := NewHTTPCollector("http://localhost:10000/api/v1/spans")
+	t.Parallel()
+
+	port := 10000
+	server := newHTTPServer(t, port)
+	c, err := NewHTTPCollector(fmt.Sprintf("http://localhost:%d/api/v1/spans", port))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +38,7 @@ func TestHttpCollector(t *testing.T) {
 	)
 
 	span := makeNewSpan("1.2.3.4:1234", serviceName, methodName, traceID, spanID, parentSpanID, true)
-	annotate(span, time.Now(), "foo", nil)
+	annotate(span, time.Now(), value, nil)
 	if err := c.Collect(span); err != nil {
 		t.Errorf("error during collection: %v", err)
 	}
@@ -37,7 +46,7 @@ func TestHttpCollector(t *testing.T) {
 		t.Fatalf("error during collection: %v", err)
 	}
 	if want, have := 1, len(server.spans()); want != have {
-		t.Fatalf("never received a span")
+		t.Fatal("never received a span")
 	}
 
 	gotSpan := server.spans()[0]
@@ -62,6 +71,115 @@ func TestHttpCollector(t *testing.T) {
 	if want, have := value, gotAnnotation.GetValue(); want != have {
 		t.Errorf("want %q, have %q", want, have)
 	}
+
+}
+
+func TestHttpCollector_Batch(t *testing.T) {
+	t.Parallel()
+
+	port := 10001
+	server := newHTTPServer(t, port)
+
+	var (
+		batchSize   = 5
+		spanTimeout = 100 * time.Millisecond
+	)
+
+	c, err := NewHTTPCollector(fmt.Sprintf("http://localhost:%d/api/v1/spans", port),
+		HTTPBatchSize(batchSize),
+		HTTPBatchInterval(time.Duration(2*batchSize)*spanTimeout), // Make sure timeout won't cause this test to pass
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < batchSize-1; i++ {
+		if err := c.Collect(&zipkincore.Span{}); err != nil {
+			t.Errorf("error during collection: %v", err)
+		}
+	}
+
+	err = consistently(func() bool { return len(server.spans()) == 0 }, spanTimeout)
+	if err != nil {
+		t.Fatal("Client sent spans before batch size")
+	}
+
+	if err := c.Collect(&zipkincore.Span{}); err != nil {
+		t.Errorf("error during collection: %v", err)
+	}
+
+	err = eventually(func() bool { return len(server.spans()) != batchSize }, time.Duration(batchSize)*time.Millisecond)
+	if err != nil {
+		t.Fatal("Client did not send spans when batch size reached")
+	}
+}
+
+func TestHttpCollector_BatchInterval(t *testing.T) {
+	t.Parallel()
+
+	port := 10002
+	server := newHTTPServer(t, port)
+
+	var (
+		batchSize     = 5
+		batchInterval = 100 * time.Millisecond
+	)
+
+	start := time.Now()
+	c, err := NewHTTPCollector(fmt.Sprintf("http://localhost:%d/api/v1/spans", port),
+		HTTPBatchSize(batchSize), // Make sure batch won't make this test pass
+		HTTPBatchInterval(batchInterval),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// send less spans than batchSize in the background
+	lessThanBatchSize := batchSize - 1
+	go func() {
+		for i := 0; i < lessThanBatchSize; i++ {
+			if err := c.Collect(&zipkincore.Span{}); err != nil {
+				t.Errorf("error during collection: %v", err)
+			}
+		}
+	}()
+
+	beforeInterval := batchInterval - (2 * interval) - time.Now().Sub(start)
+	err = consistently(func() bool { return len(server.spans()) == 0 }, beforeInterval)
+	if err != nil {
+		t.Fatal("Client sent spans before timeout")
+	}
+
+	afterInterval := batchInterval * 2
+	err = eventually(func() bool { return len(server.spans()) == lessThanBatchSize }, afterInterval)
+	if err != nil {
+		t.Fatal("Client did not send spans after timeout")
+	}
+}
+
+// TestHttpCollector_NonBlockCollect tests that the Collect
+// function is non-blocking, even when the server is slow.
+// Use of the /api/v1/sleep endpoint registered in the server.
+func TestHttpCollector_NonBlockCollect(t *testing.T) {
+	t.Parallel()
+
+	port := 10003
+	newHTTPServer(t, port)
+
+	c, err := NewHTTPCollector(fmt.Sprintf("http://localhost:%d/api/v1/sleep", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	if err := c.Collect(&zipkincore.Span{}); err != nil {
+		t.Errorf("error during collection: %v", err)
+	}
+
+	if time.Now().Sub(start) >= serverSleep {
+		t.Fatal("Collect is blocking")
+	}
+
 }
 
 type httpServer struct {
@@ -76,13 +194,22 @@ func (s *httpServer) spans() []*zipkincore.Span {
 	return s.zipkinSpans
 }
 
-func newHTTPServer(t *testing.T) *httpServer {
+func (s *httpServer) clearSpans() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.zipkinSpans = s.zipkinSpans[:0]
+}
+
+func newHTTPServer(t *testing.T, port int) *httpServer {
 	server := &httpServer{
 		t:           t,
 		zipkinSpans: make([]*zipkincore.Span, 0),
 		mutex:       sync.RWMutex{},
 	}
-	http.HandleFunc("/api/v1/spans", func(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.NewServeMux()
+
+	handler.HandleFunc("/api/v1/spans", func(w http.ResponseWriter, r *http.Request) {
 		contextType := r.Header.Get("Content-Type")
 		if contextType != "application/x-thrift" {
 			t.Fatalf(
@@ -124,9 +251,35 @@ func newHTTPServer(t *testing.T) *httpServer {
 		server.zipkinSpans = append(server.zipkinSpans, spans...)
 	})
 
+	handler.HandleFunc("/api/v1/sleep", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(serverSleep)
+	})
+
 	go func() {
-		http.ListenAndServe(":10000", nil)
+		http.ListenAndServe(fmt.Sprintf(":%d", port), handler)
 	}()
 
 	return server
+}
+
+func consistently(assertion func() bool, atList time.Duration) error {
+	deadline := time.Now().Add(atList)
+	for time.Now().Before(deadline) {
+		if !assertion() {
+			return fmt.Errorf("failed")
+		}
+		time.Sleep(interval)
+	}
+	return nil
+}
+
+func eventually(assertion func() bool, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if assertion() {
+			return nil
+		}
+		time.Sleep(interval)
+	}
+	return fmt.Errorf("failed")
 }


### PR DESCRIPTION
`http.collector.Collect` was blocking, thus interfering with application
performance when zipkin is slow, not responding or down. The collect
function could take up to `c.client.Timeout`.

This fix makes the Collect function asynchronous, sending all the
spans in the batch, and remove them from the batch once succeeds.

Add some tests to verify the batching and timouting issues.