### PR TITLE
Closes #41: collector-http error logs are too verbose

### DIFF
--- a/collector-http.go
+++ b/collector-http.go
@@ -15,7 +15,7 @@ import (
 const defaultHTTPTimeout = time.Second * 5
 
 // defaultBatchInterval in seconds
-const defaultHTTPBatchInterval = 1
+const defaultHTTPBatchInterval = time.Second * 1
 
 const defaultHTTPBatchSize = 100
 
@@ -92,7 +92,7 @@ func NewHTTPCollector(url string, options ...HTTPOption) (Collector, error) {
 		logger:        logger,
 		url:           url,
 		client:        &http.Client{Timeout: defaultHTTPTimeout},
-		batchInterval: defaultHTTPBatchInterval * time.Second,
+		batchInterval: defaultHTTPBatchInterval,
 		batchSize:     defaultHTTPBatchSize,
 		maxBacklog:    defaultHTTPMaxBacklog,
 		batch:         []*zipkincore.Span{},

--- a/collector-http.go
+++ b/collector-http.go
@@ -21,8 +21,8 @@ const defaultHTTPBatchSize = 100
 
 const defaultHTTPMaxBacklog = 1000
 
-// defaultLogErrorInterval
-const defaultLogErrorInterval = time.Second * 60
+// defaultLogErrorInterval, set to by default log every error
+const defaultLogErrorInterval = time.Second * 0
 
 // HTTPCollector implements Collector by forwarding spans to a http server.
 type HTTPCollector struct {

--- a/state-logger.go
+++ b/state-logger.go
@@ -30,25 +30,25 @@ func NewStateLogger(logger Logger, logErrorInterval time.Duration) *StateLogger 
 
 // LogError logs an error if it is different from the last seen error,
 // or that logErrorInterval have passed since the last reported error.
-func (se *StateLogger) LogError(err error) {
-	se.mutex.Lock()
-	defer se.mutex.Unlock()
-	if err == se.lastError && time.Since(se.lastErrorTime) < se.logErrorInterval {
+func (sl *StateLogger) LogError(err error) {
+	sl.mutex.Lock()
+	defer sl.mutex.Unlock()
+	if err == sl.lastError && time.Since(sl.lastErrorTime) < sl.logErrorInterval {
 		return
 	}
-	se.logger.Log("err", err.Error())
-	se.lastError = err
-	se.lastErrorTime = time.Now()
+	sl.logger.Log("err", err.Error())
+	sl.lastError = err
+	sl.lastErrorTime = time.Now()
 }
 
 // Fixed makes the stateLogger understand that the state is fixed, and when
 // the next error will occur, it will log it.
-func (se *StateLogger) Fixed(keyVal ...interface{}) {
-	se.mutex.Lock()
-	defer se.mutex.Unlock()
-	if se.logErrorInterval == 0 || se.lastError == nil {
+func (sl *StateLogger) Fixed(keyVal ...interface{}) {
+	sl.mutex.Lock()
+	defer sl.mutex.Unlock()
+	if sl.logErrorInterval == 0 || sl.lastError == nil {
 		return
 	}
-	se.logger.Log(keyVal...)
-	se.lastError = nil
+	sl.logger.Log(keyVal...)
+	sl.lastError = nil
 }

--- a/state-logger.go
+++ b/state-logger.go
@@ -1,12 +1,12 @@
 package zipkintracer
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 	"time"
 )
 
-var errNoError = fmt.Errorf("not an error")
+var errNoError = errors.New("not an error")
 
 // StateLogger is a Logger that logs error only if logErrorInterval have passed
 // from the last error, or it is a different error than the last seen.
@@ -34,7 +34,7 @@ func (sl *StateLogger) LogError(err error) {
 	if sl.logErrorInterval != 0 {
 		sl.mutex.Lock()
 		defer sl.mutex.Unlock()
-		if err == sl.lastError && time.Since(sl.lastErrorTime) < sl.logErrorInterval {
+		if err.Error() == sl.lastError.Error() && time.Since(sl.lastErrorTime) < sl.logErrorInterval {
 			return
 		}
 		sl.lastError = err
@@ -54,10 +54,10 @@ func (sl *StateLogger) Fixed(keyVal ...interface{}) {
 
 	sl.mutex.Lock()
 	defer sl.mutex.Unlock()
-	if sl.lastError == nil {
+	if sl.lastError == errNoError {
 		return
 	}
-	sl.lastError = nil
+	sl.lastError = errNoError
 
 	sl.logger.Log(keyVal...)
 }

--- a/state-logger.go
+++ b/state-logger.go
@@ -1,0 +1,54 @@
+package zipkintracer
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+var errNoError = fmt.Errorf("not an error")
+
+// StateLogger is a Logger that logs error only if logErrorInterval have passed
+// from the last error, or it is a different error than the last seen.
+type StateLogger struct {
+	logger           Logger
+	logErrorInterval time.Duration
+	lastError        error
+	lastErrorTime    time.Time
+	mutex            *sync.Mutex
+}
+
+// NewStateLogger creates a new stateLogger
+func NewStateLogger(logger Logger, logErrorInterval time.Duration) *StateLogger {
+	return &StateLogger{
+		logger:           logger,
+		logErrorInterval: logErrorInterval,
+		lastError:        errNoError,
+		mutex:            &sync.Mutex{},
+	}
+}
+
+// LogError logs an error if it is different from the last seen error,
+// or that logErrorInterval have passed since the last reported error.
+func (se *StateLogger) LogError(err error) {
+	se.mutex.Lock()
+	defer se.mutex.Unlock()
+	if err == se.lastError && time.Since(se.lastErrorTime) < se.logErrorInterval {
+		return
+	}
+	se.logger.Log("err", err.Error())
+	se.lastError = err
+	se.lastErrorTime = time.Now()
+}
+
+// Fixed makes the stateLogger understand that the state is fixed, and when
+// the next error will occur, it will log it.
+func (se *StateLogger) Fixed(keyVal ...interface{}) {
+	se.mutex.Lock()
+	defer se.mutex.Unlock()
+	if se.logErrorInterval == 0 || se.lastError == nil {
+		return
+	}
+	se.logger.Log(keyVal...)
+	se.lastError = nil
+}

--- a/state-logger_test.go
+++ b/state-logger_test.go
@@ -1,0 +1,105 @@
+package zipkintracer
+
+import (
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+	"fmt"
+)
+
+
+type mockLogger struct {
+	mock.Mock
+}
+
+// Log is a mock for the log function
+func (l *mockLogger) Log(keyvals ...interface{}) error {
+	args := l.Called(keyvals...)
+	return args.Error(0)
+}
+
+func TestStateLogger(t *testing.T) {
+	safeWait := 100 * time.Millisecond
+	err1 := fmt.Errorf("error 1")
+	err2 := fmt.Errorf("error 2")
+	fixed := "fixed"
+
+	m := new(mockLogger)
+
+	l := NewStateLogger(m, safeWait)
+
+	m.On("Log", "err", err1.Error()).Return(nil).Once()
+	l.LogError(err1)
+	m.AssertNumberOfCalls(t, "Log", 1)
+
+	m.On("Log", "err", err2.Error()).Return(nil).Once()
+	l.LogError(err2)
+	m.AssertNumberOfCalls(t, "Log", 2)
+
+	m.On("Log", "err", err1.Error()).Return(nil).Once()
+	l.LogError(err1)
+	l.LogError(err1)
+	m.AssertNumberOfCalls(t, "Log", 3)
+
+	time.Sleep(safeWait)
+
+	m.On("Log", "err", err1.Error()).Return(nil).Once()
+	l.LogError(err1)
+	l.LogError(err1)
+	m.AssertNumberOfCalls(t, "Log", 4)
+
+	m.On("Log", "err", err2.Error()).Return(nil).Once()
+	l.LogError(err2)
+	m.AssertNumberOfCalls(t, "Log", 5)
+
+	m.On("Log", fixed).Return(nil).Once()
+	l.Fixed(fixed)
+	m.AssertNumberOfCalls(t, "Log", 6)
+
+	l.Fixed(fixed)
+	m.AssertNumberOfCalls(t, "Log", 6)
+
+	m.On("Log", "err", err2.Error()).Return(nil).Once()
+	l.LogError(err2)
+	m.AssertNumberOfCalls(t, "Log", 7)
+}
+
+func TestStateLoggerAlwaysLog(t *testing.T) {
+	err1 := fmt.Errorf("error 1")
+	err2 := fmt.Errorf("error 2")
+	fixed := "fixed"
+
+	m := new(mockLogger)
+
+	l := NewStateLogger(m, 0)
+
+	m.On("Log", "err", err1.Error()).Return(nil).Once()
+	l.LogError(err1)
+	m.AssertNumberOfCalls(t, "Log", 1)
+
+	m.On("Log", "err", err1.Error()).Return(nil).Once()
+	l.LogError(err1)
+	m.AssertNumberOfCalls(t, "Log", 2)
+
+	m.On("Log", "err", err2.Error()).Return(nil).Once()
+	l.LogError(err2)
+	m.AssertNumberOfCalls(t, "Log", 3)
+
+	m.On("Log", "err", err2.Error()).Return(nil).Once()
+	l.LogError(err2)
+	m.AssertNumberOfCalls(t, "Log", 4)
+
+	m.On("Log", "err", err1.Error()).Return(nil).Once()
+	l.LogError(err1)
+	m.AssertNumberOfCalls(t, "Log", 5)
+
+	l.Fixed(fixed)
+	m.AssertNumberOfCalls(t, "Log", 5)
+
+	l.Fixed(fixed)
+	m.AssertNumberOfCalls(t, "Log", 5)
+
+	m.On("Log", "err", err2.Error()).Return(nil).Once()
+	l.LogError(err2)
+	m.AssertNumberOfCalls(t, "Log", 6)
+}


### PR DESCRIPTION
Note: I made this branch on top of the other pull request because 
if it would have too many conflicts with the master branch. 
If you want me to make this on top of master, just ask.

Add log error interval to collector-http, which reduces the amount
of logs reported by the collector in case that remote zipkin is down.
The logging of the error will happen when the error is changed
or when the configured time elapsed.
A restore connection log will appear when the connection
is restored, and the logging interval was defined.