### PR TITLE
Monitoring platform events with zipkin-go and opentracing

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -2,72 +2,35 @@ package zipkintracer
 
 import (
 	opentracing "github.com/opentracing/opentracing-go"
+	otobserver "github.com/opentracing-contrib/go-observer"
 )
-
-// Observer can be registered with the zipkin to recieve notifications
-// about new Spans.
-// The actual registration depends on the implementation, which might look
-// like the below e.g :
-// observer := myobserver.NewObserver()
-// tracer := zipkin.NewTracer(..., zipkin.WithObserver(observer))
-//
-type Observer interface {
-	// Create and return a span observer. Called when a span starts.
-	// E.g :
-	//     func StartSpan(opName string, opts ...opentracing.StartSpanOption) {
-	//     var sp opentracing.Span
-	//     sso := opentracing.StartSpanOptions{}
-	//     var spObs opentracing.SpanObserver = observer.OnStartSpan(span, opName, sso)
-	//     ...
-	// }
-	// OnStartSpan function needs to be defined for a package exporting
-	// metrics as well.
-	OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) SpanObserver
-}
-
-// SpanObserver is created by the Observer and receives notifications about
-// other Span events.
-// zipkin should define these functions for each of the span operations
-// which should call the registered (observer) callbacks.
-type SpanObserver interface {
-	// Callback called from opentracing.Span.SetOperationName()
-	OnSetOperationName(operationName string)
-	// Callback called from opentracing.Span.SetTag()
-	OnSetTag(key string, value interface{})
-	// Callback called from opentracing.Span.Finish()
-	OnFinish(options opentracing.FinishOptions)
-}
 
 // observer is a dispatcher to other observers
 type observer struct {
-	observers []Observer
+	observers []otobserver.Observer
 }
 
 // spanObserver is a dispatcher to other span observers
 type spanObserver struct {
-	observers []SpanObserver
+	observers []otobserver.SpanObserver
 }
 
-// noopSpanObserver is used when there are no observers registered on the
-// Tracer or none of them returns span observers
-var noopSpanObserver = spanObserver{}
-
-func (o observer) OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) SpanObserver {
-	var spanObservers []SpanObserver
+func (o observer) OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) (otobserver.SpanObserver, bool) {
+	var spanObservers []otobserver.SpanObserver
 	for _, obs := range o.observers {
-		spanObs := obs.OnStartSpan(sp, operationName, options)
-		if spanObs != nil {
+		spanObs, ok := obs.OnStartSpan(sp, operationName, options)
+		if ok {
 			if spanObservers == nil {
-				spanObservers = make([]SpanObserver, 0, len(o.observers))
+				spanObservers = make([]otobserver.SpanObserver, 0, len(o.observers))
 			}
 			spanObservers = append(spanObservers, spanObs)
 		}
 	}
 	if len(spanObservers) == 0 {
-		return noopSpanObserver
+		return nil, false
 	}
 
-	return spanObserver{observers: spanObservers}
+	return spanObserver{observers: spanObservers}, true
 }
 
 func (o spanObserver) OnSetOperationName(operationName string) {

--- a/observer.go
+++ b/observer.go
@@ -1,0 +1,89 @@
+package zipkintracer
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// Observer can be registered with the zipkin to recieve notifications
+// about new Spans.
+// The actual registration depends on the implementation, which might look
+// like the below e.g :
+// observer := myobserver.NewObserver()
+// tracer := zipkin.NewTracer(..., zipkin.WithObserver(observer))
+//
+type Observer interface {
+	// Create and return a span observer. Called when a span starts.
+	// E.g :
+	//     func StartSpan(opName string, opts ...opentracing.StartSpanOption) {
+	//     var sp opentracing.Span
+	//     sso := opentracing.StartSpanOptions{}
+	//     var spObs opentracing.SpanObserver = observer.OnStartSpan(span, opName, sso)
+	//     ...
+	// }
+	// OnStartSpan function needs to be defined for a package exporting
+	// metrics as well.
+	OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) SpanObserver
+}
+
+// SpanObserver is created by the Observer and receives notifications about
+// other Span events.
+// zipkin should define these functions for each of the span operations
+// which should call the registered (observer) callbacks.
+type SpanObserver interface {
+	// Callback called from opentracing.Span.SetOperationName()
+	OnSetOperationName(operationName string)
+	// Callback called from opentracing.Span.SetTag()
+	OnSetTag(key string, value interface{})
+	// Callback called from opentracing.Span.Finish()
+	OnFinish(options opentracing.FinishOptions)
+}
+
+// observer is a dispatcher to other observers
+type observer struct {
+	observers []Observer
+}
+
+// spanObserver is a dispatcher to other span observers
+type spanObserver struct {
+	observers []SpanObserver
+}
+
+// noopSpanObserver is used when there are no observers registered on the
+// Tracer or none of them returns span observers
+var noopSpanObserver = spanObserver{}
+
+func (o observer) OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) SpanObserver {
+	var spanObservers []SpanObserver
+	for _, obs := range o.observers {
+		spanObs := obs.OnStartSpan(sp, operationName, options)
+		if spanObs != nil {
+			if spanObservers == nil {
+				spanObservers = make([]SpanObserver, 0, len(o.observers))
+			}
+			spanObservers = append(spanObservers, spanObs)
+		}
+	}
+	if len(spanObservers) == 0 {
+		return noopSpanObserver
+	}
+
+	return spanObserver{observers: spanObservers}
+}
+
+func (o spanObserver) OnSetOperationName(operationName string) {
+	for _, obs := range o.observers {
+		obs.OnSetOperationName(operationName)
+	}
+}
+
+func (o spanObserver) OnSetTag(key string, value interface{}) {
+	for _, obs := range o.observers {
+		obs.OnSetTag(key, value)
+	}
+}
+
+func (o spanObserver) OnFinish(options opentracing.FinishOptions) {
+	for _, obs := range o.observers {
+		obs.OnFinish(options)
+	}
+}

--- a/span.go
+++ b/span.go
@@ -86,6 +86,13 @@ func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
 			return s
 		}
 	}
+
+	if key == string(ext.PerfEvent) {
+		if v, ok := value.(string); ok {
+			_, _, s.EventDescs = perfevents.InitOpenEventsEnableSelf(v)
+		}
+	}
+
 	if s.trim() {
 		return s
 	}

--- a/tracer.go
+++ b/tracer.go
@@ -427,6 +427,7 @@ func (t *tracerImpl) Options() TracerOptions {
 	return t.options
 }
 
+// WithObserver assigns an initialized observer to opts.observer
 func WithObserver(observer Observer) TracerOption {
 	return func(opts *TracerOptions) error {
 		opts.observer = observer

--- a/tracer.go
+++ b/tracer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/openzipkin/zipkin-go-opentracing/flag"
+	"github.com/opentracing-contrib/perfevents/go"
 )
 
 // ErrInvalidEndpoint will be thrown if hostPort parameter is corrupted or host
@@ -283,9 +284,16 @@ func (t *tracerImpl) startSpanWithOptions(
 	// Tags.
 	tags := opts.Tags
 
+	// Perfevents
+	perfevent := opts.Perfevent
+
 	// Build the new span. This is the only allocation: We'll return this as
 	// an opentracing.Span.
 	sp := t.getSpan()
+
+	// start monitoring for the perf event(s), if any
+	_, _, sp.EventDescs = perfevents.InitOpenEventsEnableSelf(perfevent)
+
 	// Look for a parent in the list of References.
 	//
 	// TODO: would be nice if basictracer did something with all

--- a/tracer.go
+++ b/tracer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/openzipkin/zipkin-go-opentracing/flag"
-	"github.com/opentracing-contrib/perfevents/go"
 )
 
 // ErrInvalidEndpoint will be thrown if hostPort parameter is corrupted or host
@@ -284,15 +283,9 @@ func (t *tracerImpl) startSpanWithOptions(
 	// Tags.
 	tags := opts.Tags
 
-	// Perfevents
-	perfevent := opts.Perfevent
-
 	// Build the new span. This is the only allocation: We'll return this as
 	// an opentracing.Span.
 	sp := t.getSpan()
-
-	// start monitoring for the perf event(s), if any
-	_, _, sp.EventDescs = perfevents.InitOpenEventsEnableSelf(perfevent)
 
 	// Look for a parent in the list of References.
 	//
@@ -384,6 +377,12 @@ func (t *tracerImpl) startSpanInternal(
 	sp.raw.Start = startTime
 	sp.raw.Duration = -1
 	sp.raw.Tags = tags
+	for k,v := range tags {
+		if k == string(ext.PerfEvent) {
+			sp.SetTag(k, v)
+		}
+	}
+
 	if t.options.debugAssertSingleGoroutine {
 		sp.SetTag(debugGoroutineIDTag, curGoroutineID())
 	}

--- a/tracer.go
+++ b/tracer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 
 	"github.com/openzipkin/zipkin-go-opentracing/flag"
+	otobserver "github.com/opentracing-contrib/go-observer"
 )
 
 // ErrInvalidEndpoint will be thrown if hostPort parameter is corrupted or host
@@ -108,7 +109,7 @@ type TracerOptions struct {
 	// 64 and 128 bit incoming traces from upstream sources.
 	traceID128Bit bool
 
-	observer Observer
+	observer otobserver.Observer
 }
 
 // TracerOption allows for functional options.
@@ -291,7 +292,7 @@ func (t *tracerImpl) startSpanWithOptions(
 	sp := t.getSpan()
 
 	if t.options.observer != nil {
-		sp.Observer = t.options.observer.OnStartSpan(sp, operationName, opts)
+		sp.observer, _ = t.options.observer.OnStartSpan(sp, operationName, opts)
 	}
 
 	// Look for a parent in the list of References.
@@ -428,7 +429,7 @@ func (t *tracerImpl) Options() TracerOptions {
 }
 
 // WithObserver assigns an initialized observer to opts.observer
-func WithObserver(observer Observer) TracerOption {
+func WithObserver(observer otobserver.Observer) TracerOption {
 	return func(opts *TracerOptions) error {
 		opts.observer = observer
 		return nil


### PR DESCRIPTION
Perf events can provide additional insights into the performance of a
span or a sequence of spans in a trace. This patch includes the use of
a library called
"perfevents" (https://github.com/opentracing-contrib/perfevents) which
can be simply imported and used. This library is an abstraction of the
platform side of counters and operations. Right now, only the generic
perf events are supported. With this patch, one should be able to find
out the cpu-cycles, instructions, cache-references, cache-misses,
branch-instructions, branch-misses and bus cycles for a span.

The required event(s) should be supplied in the form of a string(comma
separated list if there are multiple events to be monitored) to the
StartSpan call and then, the opentracing-go library and the
zipkin-go-opentracing library should take over from there. As soon as
the span is closed, the perf event(s) count is logged with span.Log().

An example to use this with a span :
// start a span with perfevents
sp = tracer.StartSpan("read_file",
opentracing.PerfString("cache-misses,cpu-cycles"))

Upon closing the span, the events stop monitoring and are destroyed afer
the data is sent for logging.
