### PR TITLE
new: added an HTTPOption to set a custom http.Client to use.

### DIFF
--- a/collector-http.go
+++ b/collector-http.go
@@ -71,6 +71,11 @@ func HTTPBatchInterval(d time.Duration) HTTPOption {
 	return func(c *HTTPCollector) { c.batchInterval = d }
 }
 
+// HTTPClient sets a custom http client to use.
+func HTTPClient(client *http.Client) HTTPOption {
+	return func(c *HTTPCollector) { c.client = client }
+}
+
 // NewHTTPCollector returns a new HTTP-backend Collector. url should be a http
 // url for handle post request. timeout is passed to http client. queueSize control
 // the maximum size of buffer of async queue. The logger is used to log errors,


### PR DESCRIPTION
Previously it was impossible to configure advanced options in the HTTPCollector,
like TLS. This patch allows users to pass any *http.Client configured the way they like.