### PR TITLE
Adding padding to 128 bit traceIDs

### DIFF
--- a/types/traceid.go
+++ b/types/traceid.go
@@ -30,7 +30,7 @@ func (t TraceID) ToHex() string {
 		return strconv.FormatUint(t.Low, 16)
 	}
 	return fmt.Sprintf(
-		"%s%016s", strconv.FormatUint(t.High, 16), strconv.FormatUint(t.Low, 16),
+		"%016s%016s", strconv.FormatUint(t.High, 16), strconv.FormatUint(t.Low, 16),
 	)
 }
 

--- a/types/traceid_test.go
+++ b/types/traceid_test.go
@@ -1,0 +1,13 @@
+package types
+
+import "testing"
+
+func TestTraceID(t *testing.T) {
+
+	traceID := TraceID{High: 1, Low: 2}
+
+	if len(traceID.ToHex()) != 32 {
+		t.Errorf("Expected zero-padded TraceID to have 32 characters")
+	}
+
+}


### PR DESCRIPTION
In working with several other opentracing libraries (sleuth in particular,) if a low enough TraceID.High value is created, sleuth with think it's a 64bit traceID.

This is also more consistent with how the TraceID.Low is generated and displayed.