### PR TITLE
Changed default for ClientServerSameSpan to true to respect Zipkin V1 better.

### DIFF
--- a/span_test.go
+++ b/span_test.go
@@ -16,6 +16,7 @@ func TestSpan_Baggage(t *testing.T) {
 	tracer, err := NewTracer(
 		recorder,
 		WithSampler(func(_ uint64) bool { return true }),
+		WithLogger(&nopLogger{}),
 	)
 	if err != nil {
 		t.Fatalf("Unable to create Tracer: %+v", err)

--- a/tracer.go
+++ b/tracer.go
@@ -170,8 +170,11 @@ func TraceID128Bit(val bool) TracerOption {
 }
 
 // ClientServerSameSpan allows to place client-side and server-side annotations
-// for a RPC call in the same span (Zipkin V1 behavior). By default this Tracer
-// uses single host spans (so client-side and server-side in separate spans).
+// for a RPC call in the same span (Zipkin V1 behavior) or different spans
+// (more in line with other tracing solutions). By default this Tracer
+// uses shared host spans (so client-side and server-side in the same span).
+// If using separate spans you might run into trouble with Zipkin V1 as clock
+// skew issues can't be remedied at Zipkin server side.
 func ClientServerSameSpan(val bool) TracerOption {
 	return func(opts *TracerOptions) error {
 		opts.clientServerSameSpan = val
@@ -224,7 +227,7 @@ func NewTracer(recorder SpanRecorder, options ...TracerOption) (opentracing.Trac
 		logger:               &nopLogger{},
 		debugAssertSingleGoroutine: false,
 		debugAssertUseAfterFinish:  false,
-		clientServerSameSpan:       false,
+		clientServerSameSpan:       true,
 		debugMode:                  false,
 		traceID128Bit:              false,
 		maxLogsPerSpan:             10000,


### PR DESCRIPTION
In hindsight it was a bad idea to default to single host spans as regular Zipkin V1 eco systems expect both client and server side of an RPC to be in the same span. 

Without them being in the same span, issues might occur wrt items like Zipkin's clock skew correction logic.

Also updated the propagation test to include a parent span for testing the X-B3-Parentspanid header.