### PR TITLE
improve circle-ci build logic

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+test:
+  pre:
+    - mkdir -p /home/ubuntu/.go_workspace/src/github.com/openzipkin
+    - mv /home/ubuntu/zipkin-go-opentracing /home/ubuntu/.go_workspace/src/github.com/openzipkin
+    - ln -s /home/ubuntu/.go_workspace/src/github.com/openzipkin/zipkin-go-opentracing /home/ubuntu/zipkin-go-opentracing
+    - go get -u -t -v github.com/openzipkin/zipkin-go-opentracing/...
+  override:
+    - make all


### PR DESCRIPTION
current blank circle-ci logic caches dependencies. we want tests against all latest state of dependencies given we don't vendor in the library.