### PR TITLE
Treat all tag values as string

### DIFF
--- a/examples/cli_with_2_services/svc2/implementation.go
+++ b/examples/cli_with_2_services/svc2/implementation.go
@@ -28,8 +28,9 @@ func (s *svc2) Sum(ctx context.Context, a int64, b int64) (int64, error) {
 
 	// Example binary annotations.
 	span.SetTag("service", "svc2")
-	span.SetTag("key1", "value1")
-	span.SetTag("key2", 2)
+	span.SetTag("string", "some value")
+	span.SetTag("int", 123)
+	span.SetTag("bool", true)
 
 	// Example annotation
 	span.LogEvent("MyEventAnnotation")
@@ -63,7 +64,7 @@ func (s *svc2) fakeDBCall(span opentracing.Span) {
 	// hostname of the resource
 	ext.PeerHostname.Set(resourceSpan, "localhost")
 	// port of the resource
-	ext.PeerPort.Set(resourceSpan, 5432)
+	ext.PeerPort.Set(resourceSpan, 3306)
 	// let's binary annotate the query we run
 	resourceSpan.SetTag(
 		"query", "SELECT recipes FROM cookbook WHERE topic = 'world domination'",

--- a/zipkin-recorder.go
+++ b/zipkin-recorder.go
@@ -3,7 +3,6 @@ package zipkintracer
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
 	"net"
 	"strconv"
 	"time"
@@ -202,86 +201,17 @@ func annotate(span *zipkincore.Span, timestamp time.Time, value string, host *zi
 // annotateBinary annotates the span with a key and a value that will be []byte
 // encoded.
 func annotateBinary(span *zipkincore.Span, key string, value interface{}, host *zipkincore.Endpoint) {
-	var a zipkincore.AnnotationType
-	var b []byte
-	// We are not using zipkincore.AnnotationType_I16 for types that could fit
-	// as reporting on it seems to be broken on the zipkin web interface
-	// (however, we can properly extract the number from zipkin storage
-	// directly). int64 has issues with negative numbers but seems ok for
-	// positive numbers needing more than 32 bit.
-	switch v := value.(type) {
-	case bool:
-		a = zipkincore.AnnotationType_BOOL
-		b = []byte("\x00")
-		if v {
-			b = []byte("\x01")
+	if b, ok := value.(bool); ok {
+		if b {
+			value = "true"
+		} else {
+			value = "false"
 		}
-	case []byte:
-		a = zipkincore.AnnotationType_BYTES
-		b = v
-	case byte:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 4)
-		binary.BigEndian.PutUint32(b, uint32(v))
-	case int8:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 4)
-		binary.BigEndian.PutUint32(b, uint32(v))
-	case int16:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 4)
-		binary.BigEndian.PutUint32(b, uint32(v))
-	case uint16:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 4)
-		binary.BigEndian.PutUint32(b, uint32(v))
-	case int32:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 4)
-		binary.BigEndian.PutUint32(b, uint32(v))
-	case uint32:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 4)
-		binary.BigEndian.PutUint32(b, v)
-	case int64:
-		a = zipkincore.AnnotationType_I64
-		b = make([]byte, 8)
-		binary.BigEndian.PutUint64(b, uint64(v))
-	case int:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 8)
-		binary.BigEndian.PutUint32(b, uint32(v))
-	case uint:
-		a = zipkincore.AnnotationType_I32
-		b = make([]byte, 8)
-		binary.BigEndian.PutUint32(b, uint32(v))
-	case uint64:
-		a = zipkincore.AnnotationType_I64
-		b = make([]byte, 8)
-		binary.BigEndian.PutUint64(b, v)
-	case float32:
-		a = zipkincore.AnnotationType_DOUBLE
-		b = make([]byte, 8)
-		bits := math.Float64bits(float64(v))
-		binary.BigEndian.PutUint64(b, bits)
-	case float64:
-		a = zipkincore.AnnotationType_DOUBLE
-		b = make([]byte, 8)
-		bits := math.Float64bits(v)
-		binary.BigEndian.PutUint64(b, bits)
-	case string:
-		a = zipkincore.AnnotationType_STRING
-		b = []byte(v)
-	default:
-		// we have no handler for type's value, but let's get a string
-		// representation of it.
-		a = zipkincore.AnnotationType_STRING
-		b = []byte(fmt.Sprintf("%+v", value))
 	}
 	span.BinaryAnnotations = append(span.BinaryAnnotations, &zipkincore.BinaryAnnotation{
 		Key:            key,
-		Value:          b,
-		AnnotationType: a,
+		Value:          []byte(fmt.Sprintf("%+v", value)),
+		AnnotationType: zipkincore.AnnotationType_STRING,
 		Host:           host,
 	})
 }


### PR DESCRIPTION
Binary annotations in non string format have the downside of not being usable as query item in the Zipkin UI. 

Zipkin V2 is dropping support for non string values so we're switching over to automatically converting non string values to string.