### PR TITLE
Update go_package in wire.proto to reflect new spec.

### DIFF
--- a/wire/wire.proto
+++ b/wire/wire.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package zipkintracer_go.wire;
-option go_package = "wire";
+option go_package = "github.com/openzipkin/zipkin-go-opentracing/wire";
 
 message TracerState {
   fixed64 trace_id = 1;


### PR DESCRIPTION
They've changed the expected package option: golang/protobuf#139

In particular, this is needed if you include this in a project build with bazel.