### PR TITLE
fixed B3 hex encoding issues with trace identifiers.

### DIFF
--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -2,6 +2,7 @@ package zipkintracer
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -46,7 +47,7 @@ func (p *textMapPropagator) Inject(
 		return opentracing.ErrInvalidCarrier
 	}
 	carrier.Set(zipkinTraceID, sc.TraceID.ToHex())
-	carrier.Set(zipkinSpanID, strconv.FormatUint(sc.SpanID, 16))
+	carrier.Set(zipkinSpanID, fmt.Sprintf("%016x", sc.SpanID))
 	if sc.Sampled {
 		carrier.Set(zipkinSampled, "1")
 	} else {
@@ -55,7 +56,7 @@ func (p *textMapPropagator) Inject(
 
 	if sc.ParentSpanID != nil {
 		// we only set ParentSpanID header if there is a parent span
-		carrier.Set(zipkinParentSpanID, strconv.FormatUint(*sc.ParentSpanID, 16))
+		carrier.Set(zipkinParentSpanID, fmt.Sprintf("%016x", *sc.ParentSpanID))
 	}
 	// we only need to inject the debug flag if set. see flag package for details.
 	flags := sc.Flags & flag.Debug

--- a/types/traceid.go
+++ b/types/traceid.go
@@ -27,11 +27,9 @@ func TraceIDFromHex(h string) (t TraceID, err error) {
 // ToHex outputs the 128-bit traceID as hex string.
 func (t TraceID) ToHex() string {
 	if t.High == 0 {
-		return strconv.FormatUint(t.Low, 16)
+		return fmt.Sprintf("%016x", t.Low)
 	}
-	return fmt.Sprintf(
-		"%016s%016s", strconv.FormatUint(t.High, 16), strconv.FormatUint(t.Low, 16),
-	)
+	return fmt.Sprintf("%016x%016x", t.High, t.Low)
 }
 
 // Empty returns if TraceID has zero value


### PR DESCRIPTION
Lower numbers represented in HEX where not prefixed with 0's so not adhering to B3 standard which requires:

- traceid's 32 hex chars in case of 128bit / 16 hex chars in case of 64 bit
- spanid & parentspanid: 16 hex chars

closes #97 