### PR TITLE
remove span.kind from span details after having set zipkin core annotations

### DIFF
--- a/zipkin-recorder.go
+++ b/zipkin-recorder.go
@@ -161,6 +161,7 @@ func (r *Recorder) RecordSpan(sp RawSpan) {
 		default:
 			annotateBinary(span, zipkincore.LOCAL_COMPONENT, r.endpoint.GetServiceName(), r.endpoint)
 		}
+		delete(sp.Tags, string(otext.SpanKind))
 	} else {
 		annotateBinary(span, zipkincore.LOCAL_COMPONENT, r.endpoint.GetServiceName(), r.endpoint)
 	}


### PR DESCRIPTION
No need to show span.kind in Zipkin's Span details. We have our core annotations.